### PR TITLE
fix: budget overview model schema

### DIFF
--- a/app/Models/Overview.php
+++ b/app/Models/Overview.php
@@ -12,6 +12,10 @@ class Overview extends Model
 {
     use Sushi;
 
+    protected array $schema = [
+        'amount' => 'float',
+    ];
+
     public function getRows(): array
     {
         return BudgetOverview::make()->toArray();


### PR DESCRIPTION
This fixes an issue where the `amount` column on the `Overview` model was throwing a type error when being formatted. The `Money::format(...)` class expects a `float` but a `string` was being passed in.

To solve this, we now define the type for the `amount` column on the Sushi schmea.